### PR TITLE
Make profile images clickable along with the names

### DIFF
--- a/cryptonetworks.html
+++ b/cryptonetworks.html
@@ -15,7 +15,7 @@
 
     <h2>1. 🏕 There are three camps of how people think about crypto networks.</h2>
     <p>There's the money crypto camp, the tech crypto camp, and the camp for people who don't believe in the money/tech crypto camp paradigm.</p>
-    <p>💸 Money Crypto vs Tech Crypto by <span class="profile"><img src="/syllabus/src/img/erik.jpg" /><a href="https://twitter.com/eriktorenberg">Erik Torenberg</a></span>:</p>
+    <p>💸 Money Crypto vs Tech Crypto by <span class="profile"><a href="https://twitter.com/eriktorenberg"><img src="/syllabus/src/img/erik.jpg"/> Erik Torenberg</a></span>:</p>
     <div class="article">
       <blockquote>
         Money Crypto believes that censorship resistant store of wealth is paramount. This may seem strange to us living in the U.S., where we trust our banks and governments (for now!), but much of the world doesn’t have that luxury: People suffer from corrupt governments, currency controls preventing people from covering capital, and currency inflation due to government instability. <br /><br />
@@ -23,7 +23,7 @@
       </blockquote>
     </div>
     <p class="citation">source: <a href="https://www.tokendaily.co/blog/money-crypto-vs-tech-crypto">Token Daily</a></p>
-    <p>👀 Neither Crypto by <span class="profile"><img src="/syllabus/src/img/fred.jpg" /><a href="https://twitter.com/fredwilson">Fred Wilson</a></span>:</p>
+    <p>👀 Neither Crypto by <span class="profile"><a href="https://twitter.com/fredwilson"><img src="/syllabus/src/img/fred.jpg" /> Fred Wilson</a></span>:</p>
     <div class="article">
       <blockquote>
           There is a narrative in crypto land that you are either in the “crypto is money” camp or the “crypto is tech” camp.<br /><br />
@@ -36,7 +36,7 @@
     <p class="citation">source: <a href="https://avc.com/2018/09/video-of-the-week-brian-armstrong-at-disrupt/">AVC</a></p>
 
     <h2>2. 🐱 Cryptonetworks build on each other</h2>
-    <p>One of the things that is most exciting about the crypto ecosystem is the ability for anyone to build on anyone else's work. Here is a clip where <span class="profile"><img src="/syllabus/src/img/dieter.jpg" /><a href="https://twitter.com/dete73">Deiter</a></span>, the CTO of Dapper Labs / Cryptokitties talks about how other developers build new games on top of Cryptokitties without the Cryptokitties team granting access or being a gatekeeper. Watch from <span class="timeframe">3:00 until 5:25</span>.</p>
+    <p>One of the things that is most exciting about the crypto ecosystem is the ability for anyone to build on anyone else's work. Here is a clip where <span class="profile"><a href="https://twitter.com/dete73"><img src="/syllabus/src/img/dieter.jpg" /> Deiter</a></span>, the CTO of Dapper Labs / Cryptokitties talks about how other developers build new games on top of Cryptokitties without the Cryptokitties team granting access or being a gatekeeper. Watch from <span class="timeframe">3:00 until 5:25</span>.</p>
     <iframe width="560" height="315" src="https://www.youtube.com/embed/m6C_AeMF5zk?start=180" frameborder="0" allow="accelerometer; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     <p>This is kind of the dream. In the past, the inability for people to easily build on each other's work was seen as a big deterring factor to innovation:</p>
     <div class="article">
@@ -45,7 +45,7 @@
       </blockquote>
     </div>
     <p class="citation">–– <a href="https://en.wikiquote.org/wiki/Richard_Hamming">R.W. Hamming, 1968</a></p>
-    <p>One more interesting thought on openness of crypto platforms. Listen to <span class="profile"><img src="/syllabus/src/img/chrisd.jpg" /><a href="https://twitter.com/cdixon">Chris</a></span> and <span class="profile"><img src="/syllabus/src/img/fred.jpg" /><a href="https://twitter.com/fredwilson">Fred</a></span> from <span class="timeframe">41:30 -  42:54</span>:</p>
+    <p>One more interesting thought on openness of crypto platforms. Listen to <span class="profile"><img src="/syllabus/src/img/chrisd.jpg" /><a href="https://twitter.com/cdixon">Chris</a></span> and <span class="profile"><a href="https://twitter.com/fredwilson"><img src="/syllabus/src/img/fred.jpg" /> Fred</a></span> from <span class="timeframe">41:30 -  42:54</span>:</p>
     <iframe width="100%" height="300" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/504193485&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
 
     <h2>3. 🧦 Understanding Scarcity</h2>
@@ -68,7 +68,7 @@
     <p>So what's the scarce resource in cryptonetworks? One possibility is that the scarce resource in cryptonetworks is hashrate. Developers and users would opt to build on a network with the most access to hashrate and even play a premium for it in token price, because that is the scarce thing that secures the network.</p>
 
     <h3 id="second-q">II. 💰 Protocols and Networks Accruing Value</h3>
-    <p>This idea is played out in a theory called the Fat Protocol thesis by <span class="profile"><img src="/syllabus/src/img/joel.jpg" /><a href="https://twitter.com/jmonegro">Joel Monegro</a></span> which explains that the value (the scarce resource, hashrate) is in the cryptonetwork, not the overlaying dapps. This is different from in the web, where value accrues in the user facing end applications (think Facebook, Amazon, Google - the biggest tech giants are end user apps).</p>
+    <p>This idea is played out in a theory called the Fat Protocol thesis by <span class="profile"><a href="https://twitter.com/jmonegro"><img src="/syllabus/src/img/joel.jpg" />Joel Monegro</a></span> which explains that the value (the scarce resource, hashrate) is in the cryptonetwork, not the overlaying dapps. This is different from in the web, where value accrues in the user facing end applications (think Facebook, Amazon, Google - the biggest tech giants are end user apps).</p>
     <div class="article">
       <blockquote>
           The previous generation of shared protocols (TCP/IP, HTTP, SMTP, etc.) produced immeasurable amounts of value, but most of it got captured and re-aggregated on top at the applications layer, largely in the form of data (think Google, Facebook and so on). The Internet stack, in terms of how value is distributed, is composed of "thin" protocols and "fat" applications.
@@ -85,11 +85,11 @@
     <p class="citation">source: <a href="http://www.usv.com/blog/fat-protocols">Joel Monegro</a></p>
 
     <h3 id="third-q">III. 🎟 The token is the thing that accrues the value.</h3>
-    <p>Tokens are reason value accrues in the protocol layer of cryptonetworks - they for the first time let someone invest directly in the protocol layer, which wasn't possible before with HTTP, TCP, etc. The thing that is new and interesting about tokens is that they are somewhere in-between using a network and investing in the network. Hear <span class="profile"><img src="/syllabus/src/img/fred.jpg" /><a href="https://twitter.com/fredwilson">Fred Wilson</a></span> describe it, listen to <span class="timeframe">30:27 - 32:34</span>:</p>
+    <p>Tokens are reason value accrues in the protocol layer of cryptonetworks - they for the first time let someone invest directly in the protocol layer, which wasn't possible before with HTTP, TCP, etc. The thing that is new and interesting about tokens is that they are somewhere in-between using a network and investing in the network. Hear <span class="profile"><a href="https://twitter.com/fredwilson"><img src="/syllabus/src/img/fred.jpg" />Fred Wilson</a></span> describe it, listen to <span class="timeframe">30:27 - 32:34</span>:</p>
     <iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/504193485&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe>
 
     <h3 id="fourth-q">IV. 🏝 How much should a token be worth?</h3>
-    <p>There's a question of how much a token should be valued at in any network. <span class="profile"><img src="/syllabus/src/img/chrisb.jpg" /><a href="https://twitter.com/cburniske">Chris Burniske</a></span> has a guideline framework:</p>
+    <p>There's a question of how much a token should be valued at in any network. <span class="profile"><a href="https://twitter.com/cburniske"><img src="/syllabus/src/img/chrisb.jpg" /> Chris Burniske</a></span> has a guideline framework:</p>
     <div class="article">
       <blockquote>
         Within its native protocol a cryptoasset serves as a means of exchange, store of value, and unit of account. By definition, then, each cryptoasset serves as a currency in the protocol economy it supports. Since the equation of exchange is used to understand the flow of money needed to support an economy, it becomes a cornerstone to cryptoasset valuations. <br /><br />
@@ -125,9 +125,9 @@
     <p>The other thing we can take away from hashrate being the scarce resource in cryptonetworks is that whichever network has the most efficient means of producing the scarce resource (hashrate) would win. This is one reaosn why there is a huge amount of focus on developing more efficient consensus protocols.</p>
 
     <h3 id="seventh-q">VII. 🍤 How do these networks evolve?</h3>
-    <p>The last thing to talk about is how do these cryptonetworks evolve over time? Here is an interesting view by <span class="profile"><img src="/syllabus/src/img/andreasa.jpeg" /><a href="https://twitter.com/aantonop">Andreas Antonopoulos</a></span> of how products in the crypto sphere will develop. Watch from the <span class="timeframe">beginning to 7:35</span> then skip to <span class="timeframe">21:11 and watch until 22:48</span>. (This is a good one to watch on 2x speed).</p>
+    <p>The last thing to talk about is how do these cryptonetworks evolve over time? Here is an interesting view by <span class="profile"><a href="https://twitter.com/aantonop"><img src="/syllabus/src/img/andreasa.jpeg" /> Andreas Antonopoulos</a></span> of how products in the crypto sphere will develop. Watch from the <span class="timeframe">beginning to 7:35</span> then skip to <span class="timeframe">21:11 and watch until 22:48</span>. (This is a good one to watch on 2x speed).</p>
     <iframe width="560" height="315" src="https://www.youtube.com/embed/5ca70mCCf2M" frameborder="0" allow="accelerometer; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-    <p>The main takeaway here is that development will happen in iterative apps, then infrastructure, then apps again, then infratsructure again cycles. The following is by <span class="profile"><img src="/syllabus/src/img/nick.jpg" /><a href="https://twitter.com/nickgrossman">Nick Grossman</a></span> and <span class="profile"><img src="/syllabus/src/img/me.png" /><a href="https://twitter.com/thedanigrant">me</a></span></p>
+    <p>The main takeaway here is that development will happen in iterative apps, then infrastructure, then apps again, then infratsructure again cycles. The following is by <span class="profile"><img src="/syllabus/src/img/nick.jpg" /><a href="https://twitter.com/nickgrossman">Nick Grossman</a></span> and <span class="profile"><a href="https://twitter.com/thedanigrant"><img src="/syllabus/src/img/me.png" /> me</a></span></p>
     <div class="article">
       <blockquote>
         Platforms evolve from an iterative cycle of apps=>infrastructure=>apps=>infrastructure and are rarely built in an outside vacuum. <br /><br />

--- a/cryptonetworks.html
+++ b/cryptonetworks.html
@@ -45,11 +45,11 @@
       </blockquote>
     </div>
     <p class="citation">–– <a href="https://en.wikiquote.org/wiki/Richard_Hamming">R.W. Hamming, 1968</a></p>
-    <p>One more interesting thought on openness of crypto platforms. Listen to <span class="profile"><img src="/syllabus/src/img/chrisd.jpg" /><a href="https://twitter.com/cdixon">Chris</a></span> and <span class="profile"><a href="https://twitter.com/fredwilson"><img src="/syllabus/src/img/fred.jpg" /> Fred</a></span> from <span class="timeframe">41:30 -  42:54</span>:</p>
+    <p>One more interesting thought on openness of crypto platforms. Listen to <span class="profile"><a href="https://twitter.com/cdixon"><img src="/syllabus/src/img/chrisd.jpg" /> Chris</a></span> and <span class="profile"><a href="https://twitter.com/fredwilson"><img src="/syllabus/src/img/fred.jpg" /> Fred</a></span> from <span class="timeframe">41:30 -  42:54</span>:</p>
     <iframe width="100%" height="300" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/504193485&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
 
     <h2>3. 🧦 Understanding Scarcity</h2>
-    <p>In different systems there are different scarce resources. First, listen to this 90 second clip where <span class="profile"><img src="/syllabus/src/img/alexd.jpeg" /><a href="https://twitter.com/alex_danco">Alex Danco</a></span> talks about the scarcity in paradigms before cryptonetworks. Listen from <span class="timeframe">38:34 - 40:05</span>:</p>
+    <p>In different systems there are different scarce resources. First, listen to this 90 second clip where <span class="profile"><a href="https://twitter.com/alex_danco"><img src="/syllabus/src/img/alexd.jpeg" /> Alex Danco</a></span> talks about the scarcity in paradigms before cryptonetworks. Listen from <span class="timeframe">38:34 - 40:05</span>:</p>
     <iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/516656988&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe>
 
     <h2>4. 💬 Now take a break and have a conversation. We've provided conversation starters</h2>
@@ -109,7 +109,7 @@
     <p class="citation">source: <a href="https://stratechery.com/aggregation-theory/">Stratechery</a></p>
     <p>The idea in Fat Protocol thesis is that the value accrues in the shared data layer of the network, and that users can freely move between apps because they all surface the same underlying data. (Think of apps like Twitter clients. Users can move between them easily because they all curate the same tweets).</p>
     <p>Aggregation Theory would argue that no - once an end user app had enough eyeballs, it would fork the network or start adding proprietary data to retain its users. This is like how Netflix started by being an interface showing open TV data, and once it had enough eyeballs, it started creating original content, locking in users to Netflix.</p>
-    <p>This is well explained by <span class="profile"><img src="/syllabus/src/img/kyles.jpg" /><a href="https://twitter.com/KyleSamani">Kyle Samani</a></span> at Multicoin Capital:</p>
+    <p>This is well explained by <span class="profile"><a href="https://twitter.com/KyleSamani"><img src="/syllabus/src/img/kyles.jpg" /> Kyle Samani</a></span> at Multicoin Capital:</p>
     <div class="article">
       <blockquote>
         I’ll propose a thought experiment in which a dapp steals value from the protocol that its built on. <br /><br />
@@ -122,12 +122,12 @@
     <p class="citation">source: <a href="https://multicoin.capital/2018/08/08/aggregation-theory-thin-protocols-and-recentralization-augur-edition/">Multicoin Capital</a></p>
 
     <h3 id="sixth-q">VI. 🐮 What else should hashrate scarcity tell us about cryptonetworks?</h3>
-    <p>The other thing we can take away from hashrate being the scarce resource in cryptonetworks is that whichever network has the most efficient means of producing the scarce resource (hashrate) would win. This is one reaosn why there is a huge amount of focus on developing more efficient consensus protocols.</p>
+    <p>The other thing we can take away from hashrate being the scarce resource in cryptonetworks is that whichever network has the most efficient means of producing the scarce resource (hashrate) would win. This is one reason why there is a huge amount of focus on developing more efficient consensus protocols.</p>
 
     <h3 id="seventh-q">VII. 🍤 How do these networks evolve?</h3>
     <p>The last thing to talk about is how do these cryptonetworks evolve over time? Here is an interesting view by <span class="profile"><a href="https://twitter.com/aantonop"><img src="/syllabus/src/img/andreasa.jpeg" /> Andreas Antonopoulos</a></span> of how products in the crypto sphere will develop. Watch from the <span class="timeframe">beginning to 7:35</span> then skip to <span class="timeframe">21:11 and watch until 22:48</span>. (This is a good one to watch on 2x speed).</p>
     <iframe width="560" height="315" src="https://www.youtube.com/embed/5ca70mCCf2M" frameborder="0" allow="accelerometer; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-    <p>The main takeaway here is that development will happen in iterative apps, then infrastructure, then apps again, then infratsructure again cycles. The following is by <span class="profile"><img src="/syllabus/src/img/nick.jpg" /><a href="https://twitter.com/nickgrossman">Nick Grossman</a></span> and <span class="profile"><a href="https://twitter.com/thedanigrant"><img src="/syllabus/src/img/me.png" /> me</a></span></p>
+    <p>The main takeaway here is that development will happen in iterative apps, then infrastructure, then apps again, then infratsructure again cycles. The following is by <span class="profile"><a href="https://twitter.com/nickgrossman"><img src="/syllabus/src/img/nick.jpg" /> Nick Grossman</a></span> and <span class="profile"><a href="https://twitter.com/thedanigrant"><img src="/syllabus/src/img/me.png" /> me</a></span></p>
     <div class="article">
       <blockquote>
         Platforms evolve from an iterative cycle of apps=>infrastructure=>apps=>infrastructure and are rarely built in an outside vacuum. <br /><br />


### PR DESCRIPTION
Found this disqus comment on part 2: "to me it was more intuitive if the photo of Deiter was the link rather than the name. I tried to click on the pic first. Anyone else have this experience?"

I also had this experience. This PR fixes this and makes images clickable along with the names, and also corrects a small typo near the end. 


By the way, I just found this syllabus now over a year since it was originally posted. I honestly think the idea is brilliant! I went through the entire thing, and I really enjoyed it. 

